### PR TITLE
feat: add city retrieval endpoints and update queryCities method

### DIFF
--- a/app/Http/Controllers/DPDController.php
+++ b/app/Http/Controllers/DPDController.php
@@ -33,4 +33,26 @@ class DPDController
         $cities = $this->DPDService->queryCities($request->validated());
         return response()->json($cities);
     }
+
+    public function getCity(int $id): JsonResponse
+    {
+        $city = $this->DPDService->getCityById($id);
+
+        if (!$city) {
+            return response()->json(['message' => 'City not found'], 404);
+        }
+
+        return response()->json($city);
+    }
+
+    public function getCityByDpdCityId(string $dpdCityId): JsonResponse
+    {
+        $city = $this->DPDService->getCityByDpdCityId($dpdCityId);
+
+        if (!$city) {
+            return response()->json(['message' => 'City not found'], 404);
+        }
+
+        return response()->json($city);
+    }
 }

--- a/app/Services/DPDService.php
+++ b/app/Services/DPDService.php
@@ -28,12 +28,29 @@ class DPDService
      */
     public function queryCities(array $data): Collection
     {
-        $searchTerms = explode(' ', $data['query']);
-        $tsQuery = implode(' & ', array_map(fn($term) => $term . ':*', $searchTerms));
+        $query = trim((string) ($data['query'] ?? ''));
+        $searchTerms = preg_split('/\s+/', $query, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        $tsQuery = implode(' & ', array_map(static fn(string $term) => $term . ':*', $searchTerms));
 
-        return $this->cityRepository::whereRaw("to_tsvector('russian', name) @@ to_tsquery('russian', ?)")
-            ->setBindings([$tsQuery])
+        return $this->cityRepository::query()
+            ->where('country_id', '=', $data['country_id'])
+            ->whereRaw("to_tsvector('russian', name) @@ to_tsquery('russian', ?)", [$tsQuery])
             ->with('terminals')
             ->get();
+    }
+
+    public function getCityById(int $id): ?\App\Models\City
+    {
+        return $this->cityRepository::query()
+            ->with('terminals')
+            ->find($id);
+    }
+
+    public function getCityByDpdCityId(string $dpdCityId): ?\App\Models\City
+    {
+        return $this->cityRepository::query()
+            ->with('terminals')
+            ->where('city_id', '=', $dpdCityId)
+            ->first();
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,3 +16,9 @@ use App\Http\Controllers\DPDController;
 
 Route::get('cities', [DPDController::class, 'queryCities'])
     ->name('cities.query');
+Route::get('cities/by-dpd-city-id/{dpdCityId}', [DPDController::class, 'getCityByDpdCityId'])
+    ->where('dpdCityId', '[0-9]+')
+    ->name('cities.show-by-dpd-city-id');
+Route::get('cities/{id}', [DPDController::class, 'getCity'])
+    ->whereNumber('id')
+    ->name('cities.show');


### PR DESCRIPTION
- Implemented `getCity` and `getCityByDpdCityId` methods in DPDController for fetching city details by ID and DPD city ID.
- Enhanced `queryCities` method in DPDService to filter cities by country ID.
- Added corresponding routes for the new city retrieval methods in the API.